### PR TITLE
Added Napptive Support

### DIFF
--- a/mattermost.app.yaml
+++ b/mattermost.app.yaml
@@ -1,0 +1,27 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+
+metadata:
+  name: mattermost
+  description: Mattermost Server
+
+spec:
+  components:
+    - name: mattermost-server
+      type: webservice
+      properties:
+        image: mattermost/mattermost-preview:latest
+        env:
+          - name: test
+            value: "test"
+        ports:
+          - port: 8065
+            expose: true
+        resources:
+          cpu: 0.5
+          memory: 512i
+      traits:
+        - type: napptive-ingress
+          properties:
+            port: 8065
+            path: /

--- a/napptive/README.md
+++ b/napptive/README.md
@@ -1,0 +1,5 @@
+# [![Mattermost](https://user-images.githubusercontent.com/7205829/137170381-fe86eef0-bccc-4fdd-8e92-b258884ebdd7.png)](https://mattermost.com)
+
+[Mattermost](https://mattermost.com) is an open source platform for secure collaboration across the entire software development lifecycle.
+
+Deploy and preview the application for free in one click, see [GitHub](https://github.com/mattermost/mattermost-server) for more info.

--- a/napptive/mattermost.app.yaml
+++ b/napptive/mattermost.app.yaml
@@ -2,7 +2,7 @@ apiVersion: core.oam.dev/v1beta1
 kind: Application
 
 metadata:
-  name: mattermost
+  name: mattermost-preview
   description: Mattermost Server
 
 spec:
@@ -25,3 +25,14 @@ spec:
           properties:
             port: 8065
             path: /
+
+        - type: storage
+          properties:
+            pvc:
+              - name: data
+                accessModes:
+                  - ReadWriteOnce
+                mountPath: /data/db
+                resources:
+                  requests:
+                    storage: 1G

--- a/napptive/mattermost.metadata.yaml
+++ b/napptive/mattermost.metadata.yaml
@@ -1,0 +1,18 @@
+apiVersion: core.napptive.com/v1alpha1
+kind: ApplicationMetadata
+name: "Mattermost"
+version: "7.8.1"
+description: Mattermost is an open source platform for secure collaboration across the entire software development lifecycle
+keywords:
+  - "mattermost"
+  - "collaboration"
+  - "golang"
+  - "react"
+  - "react-native"
+license: "MIT"
+url: "https://mattermost.com/"
+doc: "https://docs.mattermost.com/"
+logo:
+  - src: "https://storage.googleapis.com/artifacts.playground.napptive.dev/logos/mongodb.svg"
+    type: "image/png"
+    size: "120x120"


### PR DESCRIPTION
This PR contains files I used to add my application to Napptive's Catalog -

- `mattermost.app.yaml` contains the main script to deploy the app
- `mattermost.metadata.yaml` for metadata
- `README.md` for catalog description

The catalog id is - `prathamesh-mutkure/mattermost` 

<img width="1792" alt="Screenshot 2023-04-16 at 8 32 19 PM" src="https://user-images.githubusercontent.com/28570857/232321817-f52b3fe8-7ec6-413c-9483-6428579b381f.png">

You can test using -

```
playground catalog deploy prathamesh-mutkure/mattermost:7.8.1
```

Our deployment -https://mattermost-server-8065-cgt5uelt998c97mfumv0.apps.playground.napptive.dev/signup_user_complete
